### PR TITLE
Add callbacks for elements when a layer is enabled or disabled. Add touchpressed/released callbacks.

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -177,9 +177,16 @@ function luis.newLayer(layerName)
     return true
 end
 
-function luis.setCurrentLayer(layerName)
+function luis.layerExists(layerName)
     if not luis.layers[layerName] then
         print("Error: Layer '" .. layerName .. "' does not exist.")
+        return false
+    end
+    return true
+end
+
+function luis.setCurrentLayer(layerName)
+    if not luis.layerExists(layerName) then
         return false
     end
     luis.updateLastFocusedWidget(luis.currentLayer)
@@ -215,25 +222,21 @@ function luis.popLayer()
 end
 
 function luis.enableLayer(layerName)
-    if not luis.layers[layerName] then
-        print("Error: Layer '" .. layerName .. "' does not exist.")
+    if not luis.layerExists(layerName) then
         return false
     end
     luis.enabledLayers[layerName] = true
-
     for _, element in ipairs(luis.elements[layerName]) do
         if element.onEnableLayer then
             element:onEnableLayer(layerName)
         end
     end
-
     --print("Layer '" .. layerName .. "' enabled.")
     return true
 end
 
 function luis.disableLayer(layerName)
-    if not luis.layers[layerName] then
-        print("Error: Layer '" .. layerName .. "' does not exist.")
+    if not luis.layerExists(layerName) then
         return false
     end
     luis.updateLastFocusedWidget(layerName)
@@ -248,27 +251,28 @@ function luis.disableLayer(layerName)
 end
 
 function luis.toggleLayer(layerName)
-    if not luis.layers[layerName] then
-        print("Error: Layer '" .. layerName .. "' does not exist.")
+    if not luis.layerExists(layerName) then
         return false
     end
-    luis.enabledLayers[layerName] = not luis.enabledLayers[layerName]
+    if luis.enabledLayers[layerName] then
+        luis.disableLayer(layerName)
+    else
+        luis.enableLayer(layerName)
+    end
     --local status = luis.enabledLayers[layerName] and "enabled" or "disabled"
     --print("Layer '" .. layerName .. "' " .. status .. ".")
     return true
 end
 
 function luis.isLayerEnabled(layerName)
-    if not luis.layers[layerName] then
-        print("Error: Layer '" .. layerName .. "' does not exist.")
+    if not luis.layerExists(layerName) then
         return false
     end
     return luis.enabledLayers[layerName] == true
 end
 
 function luis.removeLayer(layerName)
-    if not luis.layers[layerName] then
-        print("Error: Layer '" .. layerName .. "' does not exist.")
+    if not luis.layerExists(layerName) then
         return false
     end
 


### PR DESCRIPTION
Hi!

This pull request has two small functional additions. The first adds the ability to set a callback on an element that is triggered when a layer that it is attached to is enabled or disabled. The following is an example usage of this:

(My widget classes have stylistically diverged from your own but I think this should provide enough context for the usage of the aforementioned callback.)
```lua
--From Widget superclass:
---@param self Widget
---@param callbackType string
---@param callback fun(...:any):boolean|nil
---@return nil
function Widget:setCallback(callbackType, callback)
    self.callbacks[callbackType] = callback
end

---@param self Widget
---@param layerName string
---@return nil
function Widget:onEnableLayer(layerName)
    if self.callbacks.onEnableLayer then
        self.callbacks.onEnableLayer(layerName)
    end
end

---@param self Widget
---@param layerName string
---@return nil
function Widget:onDisableLayer(layerName)
    if self.callbacks.onDisableLayer then
        self.callbacks.onDisableLayer(layerName)
    end
end

--Usage of the onEnableLayer callback, which allows the label to be altered to match current game conditions
self.label = luis.newLabel(luis, "Select Color", 12, 2, row + 6, column)
self.label:setCallback("onEnableLayer", function(layerName)
    if game.mainMenu:isQuickPlay() then
        self.label:setText("Select Color")
    elseif game.mainMenu:isLocalMultiplayer() then
        if not self.teamOneColor then
            self.label:setText("Select Color Player One")
        else
            self.label:setText("Select Color Player Two")
        end
    end
end)
``` 

I've also made small changes to luis.disableLayer, luis.enableLayer and some other related functions to facilitate these callbacks.

The second addition is to add touchpressed and touchreleased callbacks. The primary reason for this addition is so that multiple touches can be used simultaneously.

Here is an example from my TouchButton widget:
```lua

---@param self TouchButton
---@return boolean
function TouchButton:isHovered()
    local touches = love.touch.getTouches()
    for _, id in ipairs(touches) do
        local x, y = love.touch.getPosition(id)
        if x > self.position.x and x < self.position.x + self.width and y > self.position.y and y < self.position.y + self.height then
            return true
        end
    end
    return false
end

---@param self TouchButton
---@param id userdata
---@param x number
---@param y number
---@return boolean
function TouchButton:touchpressed(id, x, y)
    if x > self.position.x and x < self.position.x + self.width and y > self.position.y and y < self.position.y + self.height then
        self:trigger()
        self.touchId = id
        return true
    end

    return false
end

---@param self TouchButton
---@param id userdata
---@param x number
---@param y number
---@return boolean
function TouchButton:touchreleased(id, x, y)
    if self.touchId == id then
        self.touchId = nil
        self:deactivate()
        return true
    end
    return false
end

---@param self TouchButton
---@return boolean
function TouchButton:click()
    --override superclass Widget click function so that no action is taken
    return self:isHovered() and not self:isPressed() and self:isClickable()
end

---@param self TouchButton
---@return boolean
function TouchButton:release()
    --override superclass Widget release function so that no action is taken
    return self:isPressed() and self:isClickable()
end
``` 