### PR TITLE
Changed the return to use the 3rdparty.utils utf8-safe one

### DIFF
--- a/widgets/dialogueBox.lua
+++ b/widgets/dialogueBox.lua
@@ -49,7 +49,7 @@ local function safeSubstring(str, startPos, endPos)
     if type(str) ~= "string" then
         return ""
     end
-    return string.sub(str, startPos, endPos)
+    return utils.utf8_sub(str, startPos, endPos)
 end
 
 -- DialogueBox widget


### PR DESCRIPTION
the typewriter effect in dialogueBox.lua was crashing when handling accented characters because string.sub cuts by bytes instead of characters. i fixed this by switching to the utils.utf8_sub function, which handles multi-byte characters and prevents the decoding error. 